### PR TITLE
Fix some things

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "git@github.com:schne324/hang-tight.git",
   "author": "Harris Schneiderman <schne324@gmail.com>",
   "license": "MIT",
-  "private": false,
+  "private": true,
   "devDependencies": {
     "@types/parcel-bundler": "^1.12.1",
     "@types/react": "^16.9.38",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "hang-tight-docs",
+  "private": true,
   "version": "1.2.0",
   "description": "Hang tight documentation",
   "main": "index.js",
@@ -17,6 +18,5 @@
     "classnames": "^2.2.6",
     "hang-tight": "^1.2.0",
     "hang-tight-react": "^1.2.0"
-  },
-  "gitHead": "aa565141ee4deb5faa1c756294f6d0d54c3530d1"
+  }
 }

--- a/packages/docs/yarn.lock
+++ b/packages/docs/yarn.lock
@@ -2466,11 +2466,6 @@ grapheme-breaker@^0.3.2:
     brfs "^1.2.0"
     unicode-trie "^0.3.1"
 
-hang-tight@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/hang-tight/-/hang-tight-1.1.0.tgz#09bdb18e25a8f2cf65b919e9b267952224764349"
-  integrity sha512-c0VOrnk1SYYqmCFttF07bcg5EnevI3YK0ya1M+Y93ZWcDmKL2hajIVzc4DQIjhzFnG+XPcrTUB70lB1dpHyuvA==
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,8 @@
   "private": false,
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "prepare": "yarn build"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.10",
@@ -18,6 +19,5 @@
   },
   "dependencies": {
     "classnames": "^2.2.6"
-  },
-  "gitHead": "aa565141ee4deb5faa1c756294f6d0d54c3530d1"
+  }
 }

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -4,6 +4,5 @@
   "main": "index.css",
   "styles": "index.css",
   "license": "MIT",
-  "private": false,
-  "gitHead": "aa565141ee4deb5faa1c756294f6d0d54c3530d1"
+  "private": false
 }


### PR DESCRIPTION
This patch fixes some stuff:

- Adds a `prepare` script to the `react` package, ensuring the package is "built" prior to publishing and enabling `yarn dev` to work
- Adds `private: true` to the "private" packages here
- Removes `gitHead` because I don't know what it is/why it's needed